### PR TITLE
Updated both Global and passport to integrate

### DIFF
--- a/src/blockchain/contracts/Global.sol
+++ b/src/blockchain/contracts/Global.sol
@@ -79,7 +79,7 @@ contract Global {
         );
         transferAuthority[UUID] = newTransfer;
 
-        // passport.addTravelRecord(UUID, "EXIT", block.timestamp);
+        passport.addTravelRecord(UUID, "EXIT", block.timestamp);
         emit departure(UUID, msg.sender);
     }
 
@@ -91,7 +91,7 @@ contract Global {
     {
         transferAuthority[UUID].isPending = false;
 
-        // passport.addTravelRecord(UUID, "ENTER", block.timestamp);
+        passport.addTravelRecord(UUID, "ENTER", block.timestamp);
         emit arrival(UUID, msg.sender);
     }
 

--- a/src/blockchain/contracts/Passport.sol
+++ b/src/blockchain/contracts/Passport.sol
@@ -51,7 +51,10 @@ contract Passport is ERC721Full, ERC721Mintable {
         emit countryRegistrationSuccess(countryCode);
     }
 
-    function createPassport(string memory UUID) public onlyVerifiedCountry() {
+    function createPassport(string memory UUID)
+        public
+        onlyVerifiedCountry(tx.origin)
+    {
         require(
             passportUUIDMapping[UUID] == 0,
             "[ERROR] A passport with this UUID has already been created"
@@ -71,7 +74,7 @@ contract Passport is ERC721Full, ERC721Mintable {
         string memory UUID,
         string memory movement,
         uint256 timestamp
-    ) public onlyVerifiedCountry() {
+    ) public onlyVerifiedCountry(tx.origin) {
         require(
             passportUUIDMapping[UUID] != 0,
             "[ERROR] No such passport has been created"
@@ -163,9 +166,9 @@ contract Passport is ERC721Full, ERC721Mintable {
         _;
     }
 
-    modifier onlyVerifiedCountry() {
+    modifier onlyVerifiedCountry(address sender) {
         require(
-            countryList[msg.sender].isVerifiedCountry,
+            countryList[sender].isVerifiedCountry,
             "[INVALID PERMISSION] Verified Country Required"
         );
         _;


### PR DESCRIPTION
Had to implement tx.origin to ensure access control is correct. I understand that there might be some concerns regarding tx.origin due tx.origin attacks. But based on this scenario, i can't see a way for that attack to be feasible in disrupting our network because the start point will always be a country network which is just one account. Please double check thou. Thanks.

Changelog:
- Uncommented all methods calls to Passport.sol in Global.sol
- Edited Passport.sol's OnlyVerifiedCountry() modifier with tx.origin to ensure access management is accounted for.

Checklist:
- [x] Merged latest develop
- [x] PR title makes sense
- [ ] (UI) Has screenshots
- [ ] Wrote new tests
